### PR TITLE
Fix fieldNames to match mock data

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ module.exports.transform = ({ data, debug, getPluginContext, log, options }) => 
         modelLabel: 'Mock data',
         projectId: '12345',
         projectEnvironment: 'master',
-        fieldNames: ['firstName', 'lastName', 'points']
+        fieldNames: ['userId', 'id', 'title', 'body']
     };
 
     // 👉 The main purpose of this method is to normalize the


### PR DESCRIPTION
Mock data used in plugin and retrieved from https://jsonplaceholder.typicode.com/posts contains other field names than specified in model schema. This commit updates fieldNames to match mock data.